### PR TITLE
ch04-typo-inspector-framework-extensions

### DIFF
--- a/01-04-AgileVisualization.txt
+++ b/01-04-AgileVisualization.txt
@@ -55,13 +55,13 @@ Class>>visualizeCallGraph
 	^ c @ RSCanvasController
 
 -----------------------------
-Class>>>inspectorVisualization
+Class>>inspectorVisualization
 	<inspectorPresentationOrder: 90 title: 'Callgraph'>	
 	^ SpRoassal3InspectorPresenter new
 		canvas: self visualizeCallGraph;
 		yourself
 
 -----------------------------
-Class>>>inspectorVisualizationContext: aContext
+Class>>inspectorVisualizationContext: aContext
 	"Remove the evaluator pane"
 	aContext withoutEvaluator


### PR DESCRIPTION
Fix minor typo in the example for extending the Inspector framework